### PR TITLE
Sample hypersphere for vMF

### DIFF
--- a/s_vae/models/backbone/utils.py
+++ b/s_vae/models/backbone/utils.py
@@ -9,7 +9,7 @@ class Reshape(torch.nn.Module):
         return x.view(-1, *self.shape)
 
 
-def sample_hypersphere(n, dim, R = 1):
+def sample_hypersphere(n, dim =3, R = 1, seed = 0):
     """ 
     This function will sample from uniform distribution on the *dim*-dimensional unit sphere. 
     The method used comes from  "Computer Generation of Distributions on
@@ -18,7 +18,8 @@ def sample_hypersphere(n, dim, R = 1):
     dim: the dimension of the sphere.
     R: radius of the sphere
     """
-
+    torch.seed(seed)
+    
     distrib = torch.distributions.MultivariateNormal(torch.zeros(dim), torch.eye(dim))
     dim_arr = torch.empty(dim, n)
 

--- a/s_vae/models/backbone/utils.py
+++ b/s_vae/models/backbone/utils.py
@@ -1,10 +1,30 @@
-from torch import nn
+import torch
 
-
-class Reshape(nn.Module):
+class Reshape(torch.nn.Module):
     def __init__(self, shape):
         super().__init__()
         self.shape = shape
 
     def forward(self, x):
         return x.view(-1, *self.shape)
+
+
+def sample_hypersphere(n, dim, R = 1):
+    """ 
+    This function will sample from uniform distribution on the *dim*-dimensional unit sphere. 
+    The method used comes from  "Computer Generation of Distributions on
+    the m-sphere" By GARY ULRICH. 
+    n: number of points to sample
+    dim: the dimension of the sphere.
+    R: radius of the sphere
+    """
+
+    distrib = torch.distributions.MultivariateNormal(torch.zeros(dim), torch.eye(dim))
+    dim_arr = torch.empty(dim, n)
+
+    for i in range(n):
+        values = distrib.sample()
+        assert(R>0)
+        dim_arr[:,i] = (values*R)/torch.linalg.norm(values, ord= 2)
+    
+    return  dim_arr


### PR DESCRIPTION
Created a function for sampling a hyper-sphere uniformly. 
This is used during the sampling of vMF. 

@tillaczel : I think we should use this one to create synthetic hypersphere dataset as well. 
Maybe I am wrong, but in the `synthetic_hypersphere.py` from #1: 

As I see it, we generate (x,y,z) where each of the coordinates is uniform(0,1) and then we normalize them to lie on the sphere.  
This is a distribution on [0,1)³ which is transformed to a sphere, whereas my method is actually a distribution on a m-dimensional sphere. 

Anyway, for the purpose of having a synthetic sphere, I do not think this is a huge deal. But since I need this function anyway, we can use it to simulate as well. 